### PR TITLE
Support `key` function

### DIFF
--- a/src/bisect.jl
+++ b/src/bisect.jl
@@ -14,6 +14,8 @@ insert just before the leftmost `x` already there.
 Optional args `lo` (default `1`) and `hi` (default `length(a) + 1`) bound the
 slice of `a` to be searched.
 
+A custom `key` function can be supplied to customize the sort order.
+
 # Examples
 
 ```jldoctest
@@ -27,16 +29,23 @@ julia> bisect_left([1, 2, 3, 3, 3, 5], 3)
 3
 ```
 """
-function bisect_left(a, x, lo = 1, hi = nothing)
+function bisect_left(a, x, lo = 1, hi = nothing; key = nothing)
     if lo < 1
         throw(BoundsError(a, lo))
     end
     if hi === nothing
         hi = length(a) + 1  # It's not `length(a)`!
     end
-    while lo < hi
-        mid = (lo + hi) ÷ 2
-        a[mid] < x ? lo = mid + 1 : hi = mid
+    if key === nothing
+        while lo < hi
+            mid = (lo + hi) ÷ 2
+            a[mid] < x ? lo = mid + 1 : hi = mid
+        end
+    else
+        while lo < hi
+            mid = (lo + hi) ÷ 2
+            key(a[mid]) < x ? lo = mid + 1 : hi = mid
+        end
     end
     return lo
 end

--- a/src/bisect.jl
+++ b/src/bisect.jl
@@ -64,6 +64,8 @@ insert just after the rightmost `x` already there.
 Optional args `lo` (default `1`) and `hi` (default `length(a) + 1`) bound the
 slice of `a` to be searched.
 
+A custom `key` function can be supplied to customize the sort order.
+
 # Examples
 
 ```jldoctest
@@ -77,16 +79,23 @@ julia> bisect_right([1, 2, 3, 3, 3, 5], 3)
 6
 ```
 """
-function bisect_right(a, x, lo = 1, hi = nothing)
+function bisect_right(a, x, lo = 1, hi = nothing; key = nothing)
     if lo < 1
         throw(BoundsError(a, lo))
     end
     if hi === nothing
         hi = length(a) + 1  # It's not `length(a)`!
     end
-    while lo < hi
-        mid = (lo + hi) ÷ 2
-        x < a[mid] ? hi = mid : lo = mid + 1
+    if key === nothing
+        while lo < hi
+            mid = (lo + hi) ÷ 2
+            x < a[mid] ? hi = mid : lo = mid + 1
+        end
+    else
+        while lo < hi
+            mid = (lo + hi) ÷ 2
+            x < key(a[mid]) ? hi = mid : lo = mid + 1
+        end
     end
     return lo
 end

--- a/src/insort.jl
+++ b/src/insort.jl
@@ -6,11 +6,18 @@ export insort_left, insort_right, insort
 Insert item `x` in array `a`, and keep it sorted assuming `a` is sorted.
 
 If `x` is already in `a`, insert it to the left of the leftmost `x`.
+
 Optional args `lo` (default `1`) and `hi` (default `length(a)`) bound the
 slice of `a` to be searched.
+
+A custom `key` function can be supplied to customize the sort order.
 """
-function insort_left(a, x, lo = 1, hi = nothing)
-    lo = bisect_left(a, x, lo, hi)
+function insort_left(a, x, lo = 1, hi = nothing; key = nothing)
+    if key === nothing
+        lo = bisect_left(a, x, lo, hi)
+    else
+        lo = bisect_left(a, key(x), lo, hi, key = key)
+    end
     return insert!(a, lo, x)
 end
 

--- a/src/insort.jl
+++ b/src/insort.jl
@@ -27,11 +27,18 @@ end
 Insert item `x` in array `a`, and keep it sorted assuming `a` is sorted.
 
 If `x` is already in `a`, insert it to the right of the rightmost `x`.
+
 Optional args `lo` (default `1`) and `hi` (default `length(a)`) bound the
 slice of `a` to be searched.
+
+A custom `key` function can be supplied to customize the sort order.
 """
-function insort_right(a, x, lo = 1, hi = nothing)
-    lo = bisect_right(a, x, lo, hi)
+function insort_right(a, x, lo = 1, hi = nothing; key = nothing)
+    if key === nothing
+        lo = bisect_right(a, x, lo, hi)
+    else
+        lo = bisect_right(a, key(x), lo, hi, key = key)
+    end
     return insert!(a, lo, x)
 end
 


### PR DESCRIPTION
I found myself needing a `key` function for `bisect_right` and noticed this library didn't support it so I had to write my own. I figured I'd see if you're interested.

I went ahead and added the `key` functionality to `bisect_left`, `insort_left`, and `insort_right`, too.